### PR TITLE
Fix blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hands-on Azure Kubernetes (AKS) demos for learning and technical presentations.
 
-This repository is to share my projects presented in my [blog](https://www.roykimca), [youtube videos](https://www.youtube.com/roykimyyz) and tech presentations.
+This repository is to share my projects presented in my [blog](https://roykim.ca), [youtube videos](https://www.youtube.com/roykimyyz) and tech presentations.
 
 - provision AKS and related Azure resources,
 - run KAITO model workspaces,


### PR DESCRIPTION
## Summary
- correct the blog URL in the root README

The link now points to the public site at https://roykim.ca.