### PR TITLE
Fix Key Vault secret environment check

### DIFF
--- a/aks-keyvault/aks-keyvault.sh
+++ b/aks-keyvault/aks-keyvault.sh
@@ -166,9 +166,8 @@ echo $podname
 kubectl exec $podname -n $keyVaultDemoNamespace -- ls /mnt/secrets-store/ 
 ## print a test secret 'ExampleSecret' held in secrets-store
 kubectl exec $podname -n $keyVaultDemoNamespace -- cat /mnt/secrets-store/ExampleSecret; echo
-## Display the environment variables that includes the secret
-kubectl exec $podname -n $keyVaultDemoNamespace -- printenv
-kubectl exec busybox-secrets-store-inline-uami -n $keyVaultDemoNamespace -- env $EXAMPLE_SECRET
+## Display the synced secret environment variable
+kubectl exec $podname -n $keyVaultDemoNamespace -- printenv EXAMPLE_SECRET
 
 
 


### PR DESCRIPTION
## Summary
- use printenv EXAMPLE_SECRET inside the pod to display the synced secret
- retain the existing $podname variable instead of hard-coding the pod name
- remove the local-shell expansion that caused the reported behavior

Fixes #1